### PR TITLE
clip change notification

### DIFF
--- a/app/components/MediaBrowser.tsx
+++ b/app/components/MediaBrowser.tsx
@@ -382,7 +382,7 @@ export default function MediaBrowser() {
 
 			{contextMenu && (
 				<div
-					className="fixed z-[9999] bg-popover border border-border rounded shadow-lg py-1 min-w-[160px]"
+					className="fixed z-9999 bg-popover border border-border rounded shadow-lg py-1 min-w-40"
 					style={{ left: contextMenu.x, top: contextMenu.y }}
 					onClick={(e) => e.stopPropagation()}
 				>

--- a/app/components/TimelineTrack.tsx
+++ b/app/components/TimelineTrack.tsx
@@ -1,6 +1,6 @@
 import { memo, useMemo } from "react";
 import { Track, Clip } from "../types/timeline";
-import TimelineClip from "./TimelineClip";
+import TimelineClip, { type ClipChangeNotification } from "./TimelineClip";
 import type { RemoteSelection } from "./MatchWS";
 
 interface TimelineTrackProps {
@@ -23,6 +23,7 @@ interface TimelineTrackProps {
 	dragPreview: { trackId: string; startTime: number; duration: number; type: "video" | "audio" } | null;
 	isLastTrack?: boolean;
 	remoteSelections?: Map<string, RemoteSelection>;
+	clipChangeNotifications?: Map<string, ClipChangeNotification[]>;
 }
 
 function TimelineTrack({
@@ -45,6 +46,7 @@ function TimelineTrack({
 	dragPreview,
 	isLastTrack,
 	remoteSelections,
+	clipChangeNotifications,
 }: TimelineTrackProps) {
 	const handleDragOver = (e: React.DragEvent) => {
 		onMediaDragOver(e, track.id);
@@ -126,6 +128,7 @@ function TimelineTrack({
 					onBladeClick={onBladeClick}
 					bladeCursorPosition={bladeCursorPosition}
 					remoteSelectors={clipRemoteSelectors.get(clip.id)}
+					changeNotifications={clipChangeNotifications?.get(clip.id)}
 				/>
 			))}
 		</div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -595,3 +595,18 @@
 .media-card:not(.interacting):hover .media-card__glare {
 	opacity: 0.35;
 }
+
+@keyframes clipNotification {
+	0% {
+		opacity: 0;
+		transform: translateX(-50%) translateY(0);
+	}
+	60% {
+		opacity: 1;
+		transform: translateX(-50%) translateY(-30px);
+	}
+	100% {
+		opacity: 0;
+		transform: translateX(-50%) translateY(-40px);
+	}
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visual notifications that display when clip properties are modified in the timeline. Notifications appear when audio settings, video/image properties, or timeline adjustments are changed, then automatically dismiss with a smooth animation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR implements a visual notification system that displays property changes when remote users modify clips on the timeline.

**Key changes:**
- Added `clipChangeNotifications` state management in `Timeline.tsx` to track property updates
- Implemented comprehensive change detection for audio properties (volume, pan, pitch, speed), video properties (position, size, rotation, zoom, flip, crop), and timeline properties (startTime, duration)
- Created `ChangeNotification` component with auto-dismiss timer and CSS animation
- Notifications appear centered on clips and fade upward over 500ms

**Issues found:**
- Invalid Tailwind CSS syntax in `MediaBrowser.tsx` - `z-9999` should use bracket notation `z-[9999]`

<h3>Confidence Score: 3/5</h3>


- This PR is mostly safe but contains a syntax error that will cause styling issues
- The notification feature implementation is solid with proper state management and cleanup. However, the invalid Tailwind syntax `z-9999` will cause the context menu z-index to fail, potentially resulting in the menu appearing behind other elements. This is a compilation/syntax issue that needs fixing before merge.
- Pay close attention to `app/components/MediaBrowser.tsx` - fix the invalid Tailwind syntax before merging

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/components/MediaBrowser.tsx | Changed z-index from bracket notation to bare number (invalid Tailwind syntax) and updated min-width utility |
| app/components/Timeline.tsx | Added comprehensive clip change notification system tracking property updates with state management |
| app/components/TimelineClip.tsx | Implemented notification display component with auto-dismiss and animation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant WS as WebSocket/Remote
    participant Timeline as Timeline Component
    participant State as clipChangeNotifications State
    participant Track as TimelineTrack
    participant Clip as TimelineClip
    participant Notif as ChangeNotification
    
    WS->>Timeline: updateRemoteClip(trackId, clipId, updates)
    Timeline->>Timeline: Find existing clip in tracks
    Timeline->>Timeline: Compare properties (volume, pan, position, etc.)
    Timeline->>Timeline: Generate notification messages
    
    alt Notifications exist
        Timeline->>State: Add notifications to Map<clipId, notifications[]>
        Timeline->>Timeline: Update timelineState with clip changes
    end
    
    Timeline->>Track: Render with clipChangeNotifications
    Track->>Clip: Pass changeNotifications for clipId
    
    Clip->>Clip: useEffect detects new notifications
    Clip->>Clip: Merge into localNotifications (dedupe by id)
    
    loop For each notification
        Clip->>Notif: Render ChangeNotification
        Notif->>Notif: Display with CSS animation
        Note over Notif: 500ms timer starts
        Notif->>Clip: onComplete callback
        Clip->>Clip: Remove notification from localNotifications
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->