### PR TITLE
remove min clip duration and clip limit checks, fix clip cutting not …

### DIFF
--- a/app/components/MainLayout.tsx
+++ b/app/components/MainLayout.tsx
@@ -20,9 +20,6 @@ interface MainLayoutProps {
 	onSelectionChange?: (selectedClips: Array<{ clipId: string; trackId: string }>) => void;
 	remoteSelections?: Map<string, RemoteSelection>;
 	onCurrentTimeChange?: (time: number) => void;
-	canAddClip?: () => { allowed: boolean; reason?: string };
-	canSplitClip?: () => { allowed: boolean; reason?: string };
-	clipSizeMin?: number;
 	clipSizeMax?: number;
 }
 
@@ -49,9 +46,6 @@ const MainLayout = forwardRef<MainLayoutRef, MainLayoutProps>(
 			onSelectionChange,
 			remoteSelections,
 			onCurrentTimeChange,
-			canAddClip,
-			canSplitClip,
-			clipSizeMin,
 			clipSizeMax,
 		},
 		ref
@@ -224,9 +218,6 @@ const MainLayout = forwardRef<MainLayoutRef, MainLayoutProps>(
 									onClipRemoved={handleClipRemoved}
 									onClipSplit={handleClipSplit}
 									remoteSelections={remoteSelections}
-									canAddClip={canAddClip}
-									canSplitClip={canSplitClip}
-									clipSizeMin={clipSizeMin}
 									clipSizeMax={clipSizeMax}
 								/>
 							</ResizablePanel>

--- a/app/components/MatchModifierBadges.tsx
+++ b/app/components/MatchModifierBadges.tsx
@@ -55,14 +55,11 @@ export function MatchModifierBadges({ matchConfig, showMaxPlayers = false, verti
 				<Tooltip>
 					<TooltipTrigger asChild>
 						<Badge variant="secondary" className="gap-1 text-xs cursor-default w-fit">
-							<HugeiconsIcon icon={ScissorIcon} className="w-3 h-3" />
-							{matchConfig.clipSizeMin}-{matchConfig.clipSizeMax}s
+							<HugeiconsIcon icon={ScissorIcon} className="w-3 h-3" />≤{matchConfig.clipSizeMax}s
 						</Badge>
 					</TooltipTrigger>
 					<TooltipContent>
-						<p>
-							Clip duration is {matchConfig.clipSizeMin}s to {matchConfig.clipSizeMax}s.
-						</p>
+						<p>Max clip duration is {matchConfig.clipSizeMax}s.</p>
 					</TooltipContent>
 				</Tooltip>
 
@@ -75,7 +72,10 @@ export function MatchModifierBadges({ matchConfig, showMaxPlayers = false, verti
 						</Badge>
 					</TooltipTrigger>
 					<TooltipContent>
-						<p>Max volume boost is {matchConfig.audioMaxDb > 0 ? "+" : ""}{matchConfig.audioMaxDb} dB.</p>
+						<p>
+							Max volume boost is {matchConfig.audioMaxDb > 0 ? "+" : ""}
+							{matchConfig.audioMaxDb} dB.
+						</p>
 					</TooltipContent>
 				</Tooltip>
 

--- a/app/components/MatchWS.tsx
+++ b/app/components/MatchWS.tsx
@@ -821,12 +821,6 @@ export function MatchWS({
 			const { matchId, userId, username } = propsRef.current;
 
 			if (constraintConfig) {
-				const limitResult = validatePlayerClipLimit(constraintConfig, playerClipCount);
-				if (!limitResult.valid) {
-					toast.error(limitResult.reason || "Clip limit reached");
-					return false;
-				}
-
 				const clipForValidation: ClipForValidation = {
 					id: clip.id,
 					type: clip.type,
@@ -1007,12 +1001,6 @@ export function MatchWS({
 			const { matchId, userId, username } = propsRef.current;
 
 			if (constraintConfig) {
-				const limitResult = validatePlayerClipLimit(constraintConfig, playerClipCount);
-				if (!limitResult.valid) {
-					toast.error(limitResult.reason || "Clip limit reached");
-					return false;
-				}
-
 				const originalForValidation: ClipForValidation = {
 					id: originalClip.id,
 					type: originalClip.type,
@@ -1093,11 +1081,6 @@ export function MatchWS({
 				return { valid: true };
 			}
 
-			const limitResult = validatePlayerClipLimit(constraintConfig, playerClipCount);
-			if (!limitResult.valid) {
-				return limitResult;
-			}
-
 			const clipForValidation: ClipForValidation = {
 				id: clip.id,
 				type: clip.type,
@@ -1115,11 +1098,6 @@ export function MatchWS({
 		(originalClip: Clip, newClip: Clip, trackId: string, timeline: TimelineForValidation): { valid: boolean; reason?: string } => {
 			if (!constraintConfig) {
 				return { valid: true };
-			}
-
-			const limitResult = validatePlayerClipLimit(constraintConfig, playerClipCount);
-			if (!limitResult.valid) {
-				return limitResult;
 			}
 
 			const originalForValidation: ClipForValidation = {

--- a/app/components/TimelineClip.tsx
+++ b/app/components/TimelineClip.tsx
@@ -208,12 +208,7 @@ function TimelineClip({
 				}}
 				onMouseDown={handleMouseDown}
 				onClick={(e) => {
-					if (toolMode === "blade") {
-						e.stopPropagation();
-						onBladeClick(e, trackId);
-					} else {
-						e.stopPropagation();
-					}
+					e.stopPropagation();
 				}}
 			>
 				{(clip.type === "video" || clip.type === "image") && thumbnails.length > 0 && (

--- a/app/hooks/useTimelineClipboard.ts
+++ b/app/hooks/useTimelineClipboard.ts
@@ -13,7 +13,6 @@ interface UseTimelineClipboardOptions {
 	onClipSelect?: (selection: { clip: Clip; trackId: string }[] | null) => void;
 	onClipAdded?: (trackId: string, clip: Clip) => void;
 	onClipRemoved?: (trackId: string, clipId: string) => void;
-	canAddClip?: () => { allowed: boolean; reason?: string };
 }
 
 interface UseTimelineClipboardReturn {
@@ -34,7 +33,6 @@ export function useTimelineClipboard({
 	onClipSelect,
 	onClipAdded,
 	onClipRemoved,
-	canAddClip,
 }: UseTimelineClipboardOptions): UseTimelineClipboardReturn {
 	const [clipboard, setClipboard] = useState<Array<{ clip: Clip; trackId: string }> | null>(null);
 
@@ -129,14 +127,6 @@ export function useTimelineClipboard({
 	const handlePasteClips = useCallback(() => {
 		if (!clipboard || clipboard.length === 0) return;
 
-		if (canAddClip) {
-			const check = canAddClip();
-			if (!check.allowed) {
-				toast.error(check.reason || "Cannot paste clips");
-				return;
-			}
-		}
-
 		const minStartTime = Math.min(...clipboard.map((c) => c.clip.startTime));
 		const offset = currentTimeRef.current - minStartTime;
 
@@ -185,7 +175,7 @@ export function useTimelineClipboard({
 		if (newClipIds.length > 0) {
 			setLastSelectedClip(newClipIds[0]);
 		}
-	}, [clipboard, currentTimeRef, updateTimelineState, onClipAdded, setSelectedClips, setLastSelectedClip, canAddClip]);
+	}, [clipboard, currentTimeRef, updateTimelineState, onClipAdded, setSelectedClips, setLastSelectedClip]);
 
 	return {
 		clipboard,

--- a/app/hooks/useTimelineDrag.ts
+++ b/app/hooks/useTimelineDrag.ts
@@ -18,7 +18,6 @@ interface UseTimelineDragOptions {
 	onClipUpdated?: (trackId: string, clip: Clip) => void;
 	onClipRemoved?: (trackId: string, clipId: string) => void;
 	onClipAdded?: (trackId: string, clip: Clip) => void;
-	clipSizeMin?: number;
 	clipSizeMax?: number;
 }
 
@@ -46,7 +45,6 @@ export function useTimelineDrag({
 	onClipUpdated,
 	onClipRemoved,
 	onClipAdded,
-	clipSizeMin,
 	clipSizeMax,
 }: UseTimelineDragOptions): UseTimelineDragReturn {
 	const [dragState, setDragState] = useState<DragState | null>(null);
@@ -214,17 +212,7 @@ export function useTimelineDrag({
 							const trimAmount = clip.startTime - latestDragState.startTime;
 							clip.duration = latestDragState.startDuration - trimAmount;
 
-							const minDuration = clipSizeMin ?? 0.1;
-							const maxDuration = clipSizeMax ?? Infinity;
-
-							if (clip.duration < minDuration) {
-								clip.duration = minDuration;
-								clip.startTime = latestDragState.startTime + latestDragState.startDuration - minDuration;
-							}
-							if (clip.duration > maxDuration) {
-								clip.duration = maxDuration;
-								clip.startTime = latestDragState.startTime + latestDragState.startDuration - maxDuration;
-							}
+								const minDuration = 0.033; // ~1 frame at 30fps
 
 							const finalTrimAmount = clip.startTime - latestDragState.startTime;
 							const newSourceIn = originalSourceIn + finalTrimAmount * speed;
@@ -244,7 +232,7 @@ export function useTimelineDrag({
 
 							newState.tracks[sourceTrackIndex].clips[clipIndex] = clip;
 						} else if (latestDragState.type === "trim-end") {
-							const minDuration = clipSizeMin ?? 0.1;
+								const minDuration = 0.033; // ~1 frame at 30fps
 							const maxTimelineDuration = prev.duration - clip.startTime;
 
 							let maxDuration = maxTimelineDuration;

--- a/app/match/[matchId]/page.tsx
+++ b/app/match/[matchId]/page.tsx
@@ -582,42 +582,6 @@ function MatchContent({
 		}
 	}, [ws?.status, ws?.subscribeToZone]);
 
-	const canAddClip = useCallback(() => {
-		const config = ws?.matchConfig;
-		const clipCount = ws?.playerClipCount ?? 0;
-
-		if (!config || config.maxClipsPerUser === 0) {
-			return { allowed: true };
-		}
-
-		if (clipCount >= config.maxClipsPerUser) {
-			return {
-				allowed: false,
-				reason: `You've reached the maximum clip limit (${config.maxClipsPerUser} clips)`,
-			};
-		}
-
-		return { allowed: true };
-	}, [ws?.matchConfig, ws?.playerClipCount]);
-
-	const canSplitClip = useCallback(() => {
-		const config = ws?.matchConfig;
-		const clipCount = ws?.playerClipCount ?? 0;
-
-		if (!config || config.maxClipsPerUser === 0) {
-			return { allowed: true };
-		}
-
-		if (clipCount >= config.maxClipsPerUser) {
-			return {
-				allowed: false,
-				reason: `You've reached the maximum clip limit (${config.maxClipsPerUser} clips). Delete a clip to split.`,
-			};
-		}
-
-		return { allowed: true };
-	}, [ws?.matchConfig, ws?.playerClipCount]);
-
 	return (
 		<div className="h-screen flex flex-col relative">
 			<TopBar
@@ -634,9 +598,6 @@ function MatchContent({
 				onSelectionChange={handleSelectionChange}
 				remoteSelections={ws?.remoteSelections}
 				onCurrentTimeChange={handleCurrentTimeChange}
-				canAddClip={canAddClip}
-				canSplitClip={canSplitClip}
-				clipSizeMin={matchConfig?.clipSizeMin}
 				clipSizeMax={matchConfig?.clipSizeMax}
 			/>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -369,34 +369,18 @@ export default function MatchmakingPage() {
 										/>
 									</div>
 
-									<div className="grid grid-cols-2 gap-4">
-										<div className="space-y-2">
-											<Label>Min Clip Duration</Label>
-											<div className="flex items-center gap-2">
-												<Slider
-													value={[matchConfig.clipSizeMin]}
-													onValueChange={([v]) => setMatchConfig({ ...matchConfig, clipSizeMin: v })}
-													min={0.1}
-													max={5}
-													step={0.1}
-													className="flex-1"
-												/>
-												<span className="text-xs text-muted-foreground w-8">{matchConfig.clipSizeMin}s</span>
-											</div>
-										</div>
-										<div className="space-y-2">
-											<Label>Max Clip Duration</Label>
-											<div className="flex items-center gap-2">
-												<Slider
-													value={[matchConfig.clipSizeMax]}
-													onValueChange={([v]) => setMatchConfig({ ...matchConfig, clipSizeMax: v })}
-													min={1}
-													max={60}
-													step={1}
-													className="flex-1"
-												/>
-												<span className="text-xs text-muted-foreground w-8">{matchConfig.clipSizeMax}s</span>
-											</div>
+									<div className="space-y-2">
+										<Label>Max Clip Duration</Label>
+										<div className="flex items-center gap-2">
+											<Slider
+												value={[matchConfig.clipSizeMax]}
+												onValueChange={([v]) => setMatchConfig({ ...matchConfig, clipSizeMax: v })}
+												min={1}
+												max={60}
+												step={1}
+												className="flex-1"
+											/>
+											<span className="text-xs text-muted-foreground w-8">{matchConfig.clipSizeMax}s</span>
 										</div>
 									</div>
 

--- a/websocket/timelineCache.ts
+++ b/websocket/timelineCache.ts
@@ -5,6 +5,7 @@ import {
 	matchConfigs,
 	matchPlayerClipCounts,
 	pendingBatches,
+	matchMessageQueues,
 	BATCH_WINDOW_MS,
 	type TimelineClip,
 	type CachedTimeline,
@@ -105,6 +106,7 @@ export function cleanupMatchResources(matchId: string): void {
 	matchClipIdMaps.delete(matchId);
 	matchConfigs.delete(matchId);
 	matchPlayerClipCounts.delete(matchId);
+	matchMessageQueues.delete(matchId);
 
 	for (const [key, batch] of pendingBatches.entries()) {
 		if (key.startsWith(`${matchId}:`)) {


### PR DESCRIPTION
…being always sent via ws

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR removes minimum clip duration constraints and per-user clip limit validations from the collaborative video editing system. The changes simplify the codebase by eliminating `clipSizeMin` and `canAddClip`/`canSplitClip` callbacks throughout the component tree.

**Key changes:**
- Removed minimum clip duration validation - only max duration enforced now
- Removed per-user clip limit checks from client and server (add/split/paste operations)
- Simplified match configuration UI - removed min duration slider
- Switched WebSocket clip broadcasts from zone-aware to global (all clients receive all updates)
- Added 300ms cooldown to prevent rapid blade cuts
- Improved `splitRemoteClip` logic to handle edge cases better
- Added match message queue infrastructure (though not yet used)

**Critical issue:**
- Blade click handler was removed from `TimelineClip` component, breaking the ability to split clips by clicking on them in blade mode. Users can only split by clicking track backgrounds now.

<h3>Confidence Score: 1/5</h3>


- This PR has a critical bug that breaks core blade functionality
- The removal of blade click handling from `TimelineClip.tsx` is a regression that prevents users from splitting clips by clicking on them. This breaks expected UX where blade mode should work anywhere on the timeline. Additionally, indentation errors in `useTimelineDrag.ts` suggest the changes weren't thoroughly tested.
- `app/components/TimelineClip.tsx` needs immediate attention to restore blade functionality. `app/hooks/useTimelineDrag.ts` has syntax issues. `websocket/handlers.ts` broadcast changes should be verified for performance impact.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/components/TimelineClip.tsx | blade click handler removed - breaks clip splitting functionality |
| app/components/Timeline.tsx | added blade cooldown, improved split logic, removed constraint checks |
| app/hooks/useTimelineDrag.ts | removed clipSizeMin, fixed indentation issues in trim logic |
| websocket/handlers.ts | removed clip limit checks, switched from zone-aware to global broadcast |
| lib/clipConstraints.ts | removed minimum duration validation, improved validateClipUpdate fallback |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Client
    participant Timeline as Timeline Component
    participant MatchWS as MatchWS
    participant WSServer as WebSocket Server
    participant Handlers as handlers.ts
    participant Cache as timelineCache
    participant Broadcast as broadcast.ts
    participant OtherClients as Other Clients

    Note over Client,OtherClients: Clip Split Operation (Before PR)
    
    Client->>Timeline: Click blade on clip
    Timeline->>Timeline: Check canSplitClip()
    Timeline->>Timeline: Validate clip limit
    Timeline->>Timeline: Calculate split positions
    Timeline->>MatchWS: onClipSplit(trackId, leftPart, rightPart)
    MatchWS->>MatchWS: validatePlayerClipLimit()
    MatchWS->>WSServer: Send CLIP_SPLIT message
    WSServer->>Handlers: handleClipSplit()
    Handlers->>Handlers: validatePlayerClipLimit()
    Handlers->>Cache: updateCacheClipSplit()
    Handlers->>Broadcast: broadcastClipMessage(with zone filtering)
    Broadcast->>OtherClients: Send to clients in zone only
    
    Note over Client,OtherClients: Clip Split Operation (After PR - BROKEN)
    
    Client->>Timeline: Click on clip (blade mode)
    Timeline->>Timeline: No handler! (removed from TimelineClip)
    Note over Timeline: Click not processed
    
    Note over Client,OtherClients: Clip Split Operation (After PR - Track Background)
    
    Client->>Timeline: Click blade on track background
    Timeline->>Timeline: Check cooldown (300ms)
    Timeline->>Timeline: Calculate split positions
    Timeline->>MatchWS: onClipSplit(trackId, leftPart, rightPart)
    Note over MatchWS: No validation!
    MatchWS->>WSServer: Send CLIP_SPLIT message
    WSServer->>Handlers: handleClipSplit()
    Note over Handlers: No clip limit check!
    Handlers->>Cache: updateCacheClipSplit()
    Handlers->>Broadcast: broadcast(no zone filtering)
    Broadcast->>OtherClients: Send to ALL clients
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->