### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ COPY websocket/tsconfig.json ./
 COPY websocket/*.ts ./
 
 COPY src/gen ./src/gen
+COPY lib/clipConstraints.ts ./lib/clipConstraints.ts
 
 RUN bun add -d bun-types @bufbuild/protobuf
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added the missing `lib/clipConstraints.ts` dependency to the websocket build stage in the Dockerfile.

- The websocket server's `handlers.ts` imports validation functions from `../lib/clipConstraints`
- Without this COPY instruction, the Docker build would fail because the dependency wouldn't be available during the `bun build` step
- This fix ensures the websocket container can successfully build and run with all required dependencies

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The change adds a single required dependency file to the Docker build that was previously missing. The file exists in the repository, is imported by websocket code, and the fix ensures the build succeeds. No logic changes, security concerns, or breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Dockerfile | Added missing clipConstraints.ts dependency to websocket build stage |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Docker as Docker Build
    participant BuildWS as build-websocket Stage
    participant ProdWS as production-websocket Stage
    
    Dev->>Docker: docker build
    Docker->>BuildWS: Start websocket build stage
    BuildWS->>BuildWS: COPY websocket/*.ts
    BuildWS->>BuildWS: COPY src/gen
    BuildWS->>BuildWS: COPY lib/clipConstraints.ts [NEW]
    Note over BuildWS: clipConstraints.ts now available<br/>for websocket code import
    BuildWS->>BuildWS: bun build server.ts
    BuildWS->>ProdWS: Copy built dist/
    ProdWS->>ProdWS: Run websocket server
    Note over ProdWS: handlers.ts can now<br/>import clipConstraints
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->