### PR TITLE
Change navigation from Home to Library

### DIFF
--- a/app/results/[matchId]/page.tsx
+++ b/app/results/[matchId]/page.tsx
@@ -118,8 +118,8 @@ export default function ResultsPage({ params }: { params: Promise<{ matchId: str
 						<CardDescription>{error || "Match not found"}</CardDescription>
 					</CardHeader>
 					<CardContent>
-						<Button onClick={() => router.push("/")} className="w-full">
-							Home
+						<Button onClick={() => router.push("/library")} className="w-full">
+							Library
 						</Button>
 					</CardContent>
 				</Card>
@@ -132,7 +132,7 @@ export default function ResultsPage({ params }: { params: Promise<{ matchId: str
 			<header className="border-b bg-card">
 				<div className="container mx-auto px-4 py-4 flex items-center justify-between">
 					<div className="flex items-center gap-4">
-						<Button variant="ghost" size="icon" onClick={() => router.push("/")}>
+						<Button variant="ghost" size="icon" onClick={() => router.push("/library")}>
 							<HugeiconsIcon icon={ArrowLeft01Icon} className="w-5 h-5" />
 						</Button>
 						<div className="flex items-center gap-3">


### PR DESCRIPTION
This updates the back (arrow>, and the error (not found) links from home (`/`) to (`/library`), which has a way better user experience if we're just looking around the library.

However, it would eventually be a bit annoying if once a match ends, we automatically go to the result page ? The best in this case would to store in a way or another if we come from a match or the library.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updated navigation in the results page to redirect to `/library` instead of `/` (home) for the back button and error state. This change improves user experience when browsing the library, as users clicking on videos from the library will return to the library when navigating back. The admin delete functionality (line 96) already navigated to `/library`, so this change makes the navigation consistent across the entire results page.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor navigation considerations
- The changes are minimal and straightforward - only updating navigation targets from `/` to `/library`. The route exists and the logic is sound. Score is 4 instead of 5 because the PR description mentions a valid concern about navigation context (whether user came from match or library) that could be addressed in future work.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/results/[matchId]/page.tsx | Changed back navigation from home (`/`) to library (`/library`) in error state and header. Creates circular navigation between library and results pages. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Library as Library Page
    participant Results as Results Page
    participant Home as Home Page

    Note over User,Home: Navigation Flow After PR

    User->>Library: Browse videos
    Library->>Results: Click video card<br/>(router.push(/results/:matchId))
    
    alt Match Found
        Results->>Results: Display match results
        User->>Results: Click back arrow
        Results->>Library: Navigate back<br/>(router.push(/library))
    else Match Not Found
        Results->>Results: Show error card
        User->>Results: Click "Library" button
        Results->>Library: Navigate back<br/>(router.push(/library))
    end
    
    Note over Library,Results: Circular navigation:<br/>Library ⟷ Results
    
    Note over Home: Home page (/) is now<br/>disconnected from<br/>this flow
```

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->